### PR TITLE
Upgrade to Debian 9.0 Stretch with Python 3.5

### DIFF
--- a/build-tensor-pi/Dockerfile
+++ b/build-tensor-pi/Dockerfile
@@ -1,19 +1,21 @@
-FROM multiarch/debian-debootstrap:armhf-jessie
+FROM multiarch/debian-debootstrap:armhf-stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         curl \
         libatlas3-base \
         libfreetype6-dev \
-        libpng12-dev \
+        libpng-dev \
         libzmq3-dev \
         pkg-config \
-        python \
-        python-dev \
+        python3 \
+        python3-dev \
         rsync \
         unzip \
     && apt-get clean && \
         rm -rf /var/lib/apt/lists/*
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 WORKDIR /tmp
 COPY get-pip.py /tmp/

--- a/build-tensor-pi/Dockerfile
+++ b/build-tensor-pi/Dockerfile
@@ -23,7 +23,7 @@ RUN python /tmp/get-pip.py && \
         rm /tmp/get-pip.py
 
 COPY pip.conf /etc/pip.conf
-RUN pip --no-cache-dir install "numpy==1.15.0"
+RUN pip --no-cache-dir install "numpy==1.14.5"
 RUN pip --no-cache-dir install \
         ipykernel \
         jupyter \


### PR DESCRIPTION
Upgraded packages:
- libpng16-dev (from libpng12-dev)
- python3
- python3-dev